### PR TITLE
Switch implementation to use sockets

### DIFF
--- a/deno-bootstrap/index.ts
+++ b/deno-bootstrap/index.ts
@@ -1,23 +1,12 @@
-const scriptType = Deno.args[0];
-const script = Deno.args[1];
+const socketFile = Deno.args[0];
+const scriptType = Deno.args[1];
+const script = Deno.args[2];
 
 const importURL =
   scriptType == "import"
     ? script
     : "data:text/tsx," + encodeURIComponent(script);
 
-const server = Deno.listen({
-  hostname: "0.0.0.0",
-  port: 0,
-});
-
-const addr = server.addr as Deno.NetAddr;
-
-console.log(`deno-listening-port ${addr.port.toString().padStart(5, " ")} `);
-
-// Now that we're listening, start executing user-provided code. We could
-// import while starting the server for a small performance improvement,
-// but it would complicate reading the port from the Deno logs.
 const handler = await import(importURL);
 if (!handler.default) {
   throw new Error("No default export found in script.");
@@ -26,32 +15,19 @@ if (typeof handler.default !== "function") {
   throw new Error("Default export is not a function.");
 }
 
-const conn = await server.accept();
-(async () => {
-  // Reject all additional connections.
-  for await (const conn of server) {
-    conn.close();
-  }
-})();
+Deno.serve({ path: socketFile }, (req: Request) => {
+  const url = new URL(req.url);
+  url.host = req.headers.get("X-Deno-Worker-Host") || url.host;
+  url.port = req.headers.get("X-Deno-Worker-Port") || url.port;
+  url.href = url.href.replace(
+    /^http\+unix:/,
+    req.headers.get("X-Deno-Worker-Protocol") || url.protocol
+  );
+  // Deno Request headers are immutable so we must make a new Request in order to delete our headers
+  req = new Request(url.toString(), req);
+  req.headers.delete("X-Deno-Worker-Host");
+  req.headers.delete("X-Deno-Worker-Protocol");
+  req.headers.delete("X-Deno-Worker-Port");
 
-// serveHttp is deprecated, but we don't have many other options if we'd like to
-// keep this pattern of rejecting future connections at the TCP level.
-// https://discord.com/channels/684898665143206084/1232398264947445810/1234614780111880303
-//
-// deno-lint-ignore no-deprecated-deno-api
-const httpConn = Deno.serveHttp(conn);
-for await (const requestEvent of httpConn) {
-  (async () => {
-    let req = requestEvent.request;
-    const url = new URL(req.url);
-    url.host = req.headers.get("X-Deno-Worker-Host") || url.host;
-    url.protocol = req.headers.get("X-Deno-Worker-Protocol") + ":";
-    url.port = req.headers.get("X-Deno-Worker-Port") || url.port;
-    req = new Request(url.toString(), req);
-    req.headers.delete("X-Deno-Worker-Host");
-    req.headers.delete("X-Deno-Worker-Protocol");
-    req.headers.delete("X-Deno-Worker-Port");
-
-    await requestEvent.respondWith(handler.default(req));
-  })();
-}
+  return handler.default(req);
+});

--- a/sockets/client.ts
+++ b/sockets/client.ts
@@ -1,0 +1,6 @@
+import htt2 from "http2-wrapper";
+import net from "net";
+
+const client = htt2.connect("http://whatever", {
+  createConnection: () => net.connect("787562857674825-deno-http.sock"),
+});

--- a/sockets/deno.ts
+++ b/sockets/deno.ts
@@ -1,0 +1,3 @@
+Deno.serve({ path: "./socket.sock" }, async (r: Request) => {
+  return Response.json({ ok: true });
+});


### PR DESCRIPTION
@tmcw this works and makes the network security space much simpler. We can even now run deno with `--deny-net`.