### PR TITLE
Add global uncaught exception handler

### DIFF
--- a/deno-bootstrap/index.ts
+++ b/deno-bootstrap/index.ts
@@ -17,7 +17,7 @@ if (typeof mod.default.fetch !== "function") {
 
 const onError =
   mod.default.onError ??
-  function (error) {
+  function (error: unknown) {
     console.error(error);
     return new Response("Internal Server Error", { status: 500 });
   };
@@ -56,6 +56,11 @@ const server = Deno.serve(
     return mod.default.fetch(req);
   }
 );
+
+globalThis.onerror = (e) => {
+  console.error(e.error);
+  e.preventDefault();
+};
 
 Deno.addSignalListener("SIGINT", async () => {
   // On interrupt we only shut down the server. Deno will wait for all

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deno-http-worker",
-  "version": "0.0.9",
+  "version": "0.0.11",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
@tmcw what do you think about this? I'm not sure if this should live here or in implementing applications. I got to this point trying to catch errors that happen during streaming response bodies. Without this handler, the process will crash, but this doesn't improve the http-level experience much for the user because the request that fails will still hang, they just might get a helpful log along with it. 

Alternatively we could do something much more invasive where we wrap the Response.body value and attempt to catch all errors on that API surface. This would mean request-level errors, but would be lots of work. 

Also worth noting that all of this is happening after the response headers have been written, so there might be an opportunity to improve observability and user experience, but not much we can do to turn the http response into an error message. 