### PR TITLE
Add option to allow deno executable path to be an array of arguments

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deno-http-worker",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
So you can do things like:
```ts
      {
        printOutput: true,
        denoExecutable: ["lurk", "-f", "-s", "1000", "deno"],
      }
```