### PR TITLE
Return non-error status on warmup and delete internal headers

### DIFF
--- a/deno-bootstrap/index.ts
+++ b/deno-bootstrap/index.ts
@@ -34,7 +34,7 @@ const server = Deno.serve(
     const headerUrl = req.headers.get("X-Deno-Worker-URL");
     if (!headerUrl) {
       // This is just for the warming request, shouldn't be seen by clients.
-      return Response.json({}, { status: 200 });
+      return Response.json({ warming: true }, { status: 200 });
     }
     const url = new URL(headerUrl);
     // Deno Request headers are immutable so we must make a new Request in order

--- a/deno-bootstrap/index.ts
+++ b/deno-bootstrap/index.ts
@@ -34,7 +34,7 @@ const server = Deno.serve(
     const headerUrl = req.headers.get("X-Deno-Worker-URL");
     if (!headerUrl) {
       // This is just for the warming request, shouldn't be seen by clients.
-      return Response.json({}, { status: 401 });
+      return Response.json({}, { status: 200 });
     }
     const url = new URL(headerUrl);
     // Deno Request headers are immutable so we must make a new Request in order
@@ -53,6 +53,8 @@ const server = Deno.serve(
       );
 
     req.headers.delete("X-Deno-Worker-URL");
+    req.headers.delete("X-Deno-Worker-Host");
+    req.headers.delete("X-Deno-Worker-Connection");
     return mod.default.fetch(req);
   }
 );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "deno-http-worker",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "description": "",
   "main": "dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION
The 401 header was causing noise in our system because our tracing lib was reporting it as an error. So we switch to a 200 response, but return a body to help someone debugging this if they are somehow not setting X-Deno-Worker-URL.

X-Deno-Worker-Host and X-Deno-Worker-Connection were also leaking. Delete them.