### PR TITLE
Add files entry to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   "engines": {
     "node": "20 || 22"
   },
-  "author": "",
+  "author": "Val Town",
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/val-town/deno-http-worker/issues"

--- a/package.json
+++ b/package.json
@@ -13,6 +13,10 @@
     "build": "tsc --build",
     "prepare": "npm run lint && npm run build"
   },
+  "files": [
+    "dist",
+    "deno-bootstrap"
+  ],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/val-town/deno-http-worker.git"


### PR DESCRIPTION
We've been including the `.github` metadata directory and the raw `src` directory in distributed versions of this module. This adds a `files` entry to exclude them.