### PR TITLE
Detect Worker Readiness Every 1 Millisecond Instead of Every 20 Milliseconds

### DIFF
--- a/.changeset/faster-readiness.md
+++ b/.changeset/faster-readiness.md
@@ -1,0 +1,5 @@
+---
+"@valtown/deno-http-worker": patch
+---
+
+Detect worker readiness via a 1ms socket connect-retry loop instead of a 20ms fs.stat poll, cutting ~17ms of detection latency from every spawn

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -242,7 +242,11 @@ export const newDenoHTTPWorker = async (
       // Try connecting to the Deno process every 1ms
       for (;;) {
         if (exited) {
-          break;
+          // The "exit" handler above has already rejected this promise with
+          // EarlyExitDenoHTTPWorkerError. Throw (harmlessly swallowed by the
+          // settled promise) instead of falling through and constructing a
+          // worker whose http.Agent would never be destroyed.
+          throw new Error("Deno exited before being ready");
         }
         const connected = await new Promise<boolean>((resolve) => {
           const socket = net.connect({ path: socketFile });
@@ -262,7 +266,15 @@ export const newDenoHTTPWorker = async (
       }
       worker = new denoHTTPWorker(socketFile, process, stdout, stderr);
       running = true;
-      await (worker as denoHTTPWorker).warmRequest();
+      try {
+        await (worker as denoHTTPWorker).warmRequest();
+      } catch (err) {
+        // Clean up the worker (destroying its http.Agent) if the warm
+        // request fails, e.g. because the process died right after the
+        // socket came up.
+        (worker as denoHTTPWorker)._terminate();
+        throw err;
+      }
 
       return worker;
     })()

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -3,6 +3,7 @@ import { spawn, type SpawnOptions } from "node:child_process";
 import type { Readable } from "node:stream";
 import readline from "node:readline";
 import http from "node:http";
+import net from "node:net";
 import fs from "node:fs/promises";
 import os from "node:os";
 
@@ -238,18 +239,29 @@ export const newDenoHTTPWorker = async (
         });
       }
 
-      // Wait for the socket file to be created by the Deno process.
+      // Wait for the Deno process to start listening on the socket. We retry a
+      // real connection rather than polling fs.stat: the socket file can exist
+      // before listen() finishes, and a 1ms connect retry detects readiness an
+      // order of magnitude sooner than a 20ms stat poll.
       for (;;) {
         if (exited) {
           break;
         }
-        try {
-          await fs.stat(socketFile);
-          // File exists
+        const connected = await new Promise<boolean>((resolve) => {
+          const socket = net.connect({ path: socketFile });
+          socket.once("connect", () => {
+            socket.destroy();
+            resolve(true);
+          });
+          socket.once("error", () => {
+            socket.destroy();
+            resolve(false);
+          });
+        });
+        if (connected) {
           break;
-        } catch (_err) {
-          await new Promise((resolve) => setTimeout(resolve, 20));
         }
+        await new Promise((resolve) => setTimeout(resolve, 1));
       }
       worker = new denoHTTPWorker(socketFile, process, stdout, stderr);
       running = true;

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -239,10 +239,7 @@ export const newDenoHTTPWorker = async (
         });
       }
 
-      // Wait for the Deno process to start listening on the socket. We retry a
-      // real connection rather than polling fs.stat: the socket file can exist
-      // before listen() finishes, and a 1ms connect retry detects readiness an
-      // order of magnitude sooner than a 20ms stat poll.
+      // Try connecting to the Deno process every 1ms
       for (;;) {
         if (exited) {
           break;


### PR DESCRIPTION
This PR improves first-request latency up to 20ms, mostly for free.

## Problem

The parent polls `fs.stat(socketFile)` every 20ms to learn when the Deno guest's unix socket is up. Measured on my M2 Mac, the socket is actually ready ~24ms after spawn — but the poll only checks at 20ms intervals, so it checks at 20ms (not ready yet) and doesn't check again until 40ms. We spend ~17ms waiting on a socket that's already ready.

| Phase | Time |
|---|---|
| spawn → socket listening | ~24ms |
| waiting for the next 20ms poll to notice | +~17ms |
| `warmRequest()` round trip | +~1ms |
| **Total spawn time today** | **~43ms** |

## Fix

Replace the stat poll with a 1ms connect-retry loop: try `net.connect({ path: socketFile })`, retry on error, ready on connect.

| Phase | Time |
|---|---|
| spawn → socket listening | ~24ms |
| next 1ms connect attempt succeeds | +~1ms |
| `warmRequest()` round trip | +~1ms |
| **Total spawn time after** | **~26ms** |

Connecting also proves the socket is *accepting*, not merely that the file exists, which closes a (rare) race where the socket file exists before `listen()` has finished. The `exited` check at the top of each loop iteration is preserved, so an early-exiting Deno process still hits `EarlyExitDenoHTTPWorkerError` exactly as before.

Why 1ms: a 0ms busy-loop was actually slower (~2,100 connect attempts starve the event loop); 5ms pushes detection back to ~29ms. 1ms lands at ~22 attempts and ~25ms ready-time.

Alternatives considered: having the guest print a line to stdout when `Deno.serve` starts listening is equally fast, but it adds a parent↔guest protocol and entangles with the user-overridable `onListen`; `fs.watch` is platform-fiddly. Connect-retry wins on simplicity.

## Results

**This repo's benchmark** — spawn a worker with a one-line guest 15 times, measuring spawn → first successful request:

| | median spawn |
|---|---|
| before | 44ms |
| after | 27ms |

**In the val.town monorepo** — deploy a one-line HTTP val and measure (a) the worker-spawn portion of serving the first request, via server-side trace spans, and (b) the user-visible time from submitting the edit to the endpoint serving the new code:

| | median spawn | fastest spawn | edit → endpoint live (median) |
|---|---|---|---|
| before | 46ms | 45ms | 213ms |
| after | 43ms | 33ms | 199ms |

Why the monorepo median moved less than this repo's benchmark: how much time the old 20ms poll wasted depends on where the socket's ready moment happens to land between two checks — anywhere from 0 to 20ms, essentially at random. In this repo's benchmark the ready moment (~24ms) fell just after the 20ms check, so nearly the full 17ms was wasted on every spawn and the fix reclaims all of it. The monorepo's spawn is heavier (more flags, bigger guest), so its ready moment lands later — and on my machine, close to one of the old checks, so the median only improved ~3ms there. The fastest spawns improved ~12ms. The real win is that spawn time no longer depends on this luck at all: detection is now always ~1ms after the socket is ready, instead of 0–20ms later depending on timing. In prod, that removes up to 20ms of random per-spawn latency rather than a fixed amount.

## Caveat

While waiting for the socket (~25ms), the parent now attempts a connection every 1ms, and each attempt before readiness fails immediately — so a spawn does ~22 failed connect attempts where the old code did ~2 stat calls. Each failed attempt is a few microseconds of CPU and the socket is destroyed on both the success and error paths, so nothing leaks or accumulates. The trade is a tiny constant amount of extra syscall churn per spawn in exchange for up to 20ms lower latency; if it ever mattered at very high spawn rates, the retry interval is a single constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
