### PR TITLE
Experiment: detect worker readiness with fs.watch (alternative to #120)

### DIFF
--- a/.changeset/fswatch-readiness.md
+++ b/.changeset/fswatch-readiness.md
@@ -1,0 +1,5 @@
+---
+"@valtown/deno-http-worker": patch
+---
+
+Detect worker readiness via fs.watch on a private per-worker socket directory instead of a 20ms fs.stat poll. Experimental alternative to the connect-retry approach in #120, for comparison.

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -3,6 +3,8 @@ import { spawn, type SpawnOptions } from "node:child_process";
 import type { Readable } from "node:stream";
 import readline from "node:readline";
 import http from "node:http";
+import net from "node:net";
+import { type FSWatcher, watch } from "node:fs";
 import fs from "node:fs/promises";
 import os from "node:os";
 
@@ -128,11 +130,36 @@ export const newDenoHTTPWorker = async (
 
   let scriptArgs: string[];
 
-  // Create the socket location that we'll use to communicate with Deno.
-  const socketFile = path.join(
-    os.tmpdir(),
-    `${crypto.randomUUID()}-deno-http.sock`
+  if (
+    Array.isArray(_options.denoExecutable) &&
+    _options.denoExecutable.length === 0
+  ) {
+    throw new Error("denoExecutable must not be an empty array");
+  }
+  const command =
+    typeof _options.denoExecutable === "string"
+      ? _options.denoExecutable
+      : (_options.denoExecutable[0] as string);
+
+  const bootstrap = await fs.readFile(
+    _options.denoBootstrapScriptPath,
+    "utf-8"
   );
+
+  // Create the socket location that we'll use to communicate with Deno. The
+  // socket file gets a private directory (instead of living directly in
+  // os.tmpdir()) so that the fs.watch readiness detection below only receives
+  // events for this worker's socket. Watching the shared tmpdir would wake
+  // every pending worker's watcher for every temp file created by anything
+  // else on the machine. This directory is created last, after every other
+  // failable setup step above, so a setup error can't leak it; from here on,
+  // the process "exit" handler and worker._terminate() remove it.
+  const socketDir = await fs.mkdtemp(path.join(os.tmpdir(), "deno-http-"));
+  // The directory is already unique, so the socket file gets a short fixed
+  // name: unix socket paths are limited to ~104 bytes on macOS (SUN_LEN) and
+  // the old `${randomUUID()}-deno-http.sock` name plus the new directory
+  // component overflows that limit and makes Deno's listen() throw.
+  const socketFile = path.join(socketDir, "deno-http.sock");
 
   // If we have a file import, make sure we allow read access to the file.
   const allowReadFlagValue =
@@ -171,21 +198,6 @@ export const newDenoHTTPWorker = async (
   } else {
     scriptArgs = [socketFile, "import", script.href];
   }
-  if (
-    Array.isArray(_options.denoExecutable) &&
-    _options.denoExecutable.length === 0
-  ) {
-    throw new Error("denoExecutable must not be an empty array");
-  }
-  const command =
-    typeof _options.denoExecutable === "string"
-      ? _options.denoExecutable
-      : (_options.denoExecutable[0] as string);
-
-  const bootstrap = await fs.readFile(
-    _options.denoBootstrapScriptPath,
-    "utf-8"
-  );
 
   return new Promise((resolve, reject) => {
     (async (): Promise<DenoHTTPWorker> => {
@@ -220,7 +232,7 @@ export const newDenoHTTPWorker = async (
               signal
             )
           );
-          fs.rm(socketFile).catch(() => {});
+          fs.rm(socketDir, { recursive: true, force: true }).catch(() => {});
         } else {
           (worker as denoHTTPWorker)._terminate(code, signal);
         }
@@ -238,22 +250,131 @@ export const newDenoHTTPWorker = async (
         });
       }
 
-      // Wait for the socket file to be created by the Deno process.
+      // Wait for the socket file to be created by the Deno process, using a
+      // filesystem watcher on the private directory that will contain it.
+      try {
+        await new Promise<void>((ready, failed) => {
+          let settled = false;
+          let watcher: FSWatcher | undefined;
+          let fallbackPoll: NodeJS.Timeout | undefined;
+          // Every outcome must run through settle: an open FSWatcher (or a
+          // live interval) keeps the Node event loop alive, so leaking one on
+          // any path would hang the host process on shutdown.
+          const settle = (err?: Error) => {
+            if (settled) {
+              return;
+            }
+            settled = true;
+            watcher?.close();
+            clearInterval(fallbackPoll);
+            if (err) {
+              failed(err);
+            } else {
+              ready();
+            }
+          };
+          // A watch event only tells us that something happened in the
+          // directory, not that our socket exists: on Linux (inotify) file
+          // creation is reported as a "rename" event, on macOS
+          // (FSEvents/kqueue) event types vary, and the filename argument is
+          // not guaranteed to be provided on every platform. So we ignore
+          // both arguments and stat the socket file on every event.
+          const checkForSocketFile = () => {
+            fs.stat(socketFile).then(
+              () => settle(),
+              () => {
+                // Not there yet; keep waiting for the next event.
+              }
+            );
+          };
+          try {
+            watcher = watch(socketDir, checkForSocketFile);
+          } catch (err) {
+            settle(err as Error);
+            return;
+          }
+          // Without this, a watcher error (e.g. hitting the inotify watch or
+          // file-descriptor limit) would leave this promise pending forever.
+          watcher.on("error", (err) => settle(err));
+          // fs.watch gives us no signal when the Deno process dies before
+          // ever creating the socket, so wire the process exit to settle this
+          // wait too. The "exit" handler above has already rejected the outer
+          // promise with EarlyExitDenoHTTPWorkerError; the rejection from
+          // settle is harmlessly swallowed by that already-settled promise.
+          process.on("exit", () =>
+            settle(new Error("Deno exited before being ready"))
+          );
+          if (exited) {
+            // The process exited before the listener above was registered, so
+            // that listener will never fire; settle now.
+            settle(new Error("Deno exited before being ready"));
+            return;
+          }
+          // fs.watch is documented as not perfectly reliable, and on macOS
+          // the FSEvents stream starts asynchronously, so an event landing in
+          // the window right after watch() returns can be missed. A coarse
+          // fallback poll bounds the damage of any missed event at 250ms
+          // instead of hanging forever. (Yes: a robust fs.watch needs the
+          // poll it was supposed to replace, kept only as a safety net.)
+          fallbackPoll = setInterval(checkForSocketFile, 250);
+          // The socket file may also have been created in the window between
+          // spawn and the watcher being established, in which case no event
+          // will ever fire for it. Check once, now that the watcher is in
+          // place, so the file can't slip through unobserved.
+          checkForSocketFile();
+        });
+      } catch (err) {
+        if (!exited) {
+          // A watcher failure is an error path the poll/connect designs don't
+          // have: the Deno process is still alive and nothing else will reap
+          // it, so kill it before rejecting. The "exit" handler above then
+          // removes the socket directory.
+          process.kill("SIGKILL");
+        }
+        throw err;
+      }
+
+      // The socket file existing does not prove the socket is accepting
+      // connections: the file can appear before Deno's listen() has
+      // completed. Confirm with a connect attempt, retrying every 1ms until
+      // it succeeds. Note that this reintroduces a slice of the connect-retry
+      // loop from #120 — a watch event alone is not a sufficient readiness
+      // signal.
       for (;;) {
         if (exited) {
+          // The "exit" handler above has already rejected this promise with
+          // EarlyExitDenoHTTPWorkerError. Throw (harmlessly swallowed by the
+          // settled promise) instead of falling through and constructing a
+          // worker whose http.Agent would never be destroyed.
+          throw new Error("Deno exited before being ready");
+        }
+        const connected = await new Promise<boolean>((resolve) => {
+          const socket = net.connect({ path: socketFile });
+          socket.once("connect", () => {
+            socket.destroy();
+            resolve(true);
+          });
+          socket.once("error", () => {
+            socket.destroy();
+            resolve(false);
+          });
+        });
+        if (connected) {
           break;
         }
-        try {
-          await fs.stat(socketFile);
-          // File exists
-          break;
-        } catch (_err) {
-          await new Promise((resolve) => setTimeout(resolve, 20));
-        }
+        await new Promise((resolve) => setTimeout(resolve, 1));
       }
       worker = new denoHTTPWorker(socketFile, process, stdout, stderr);
       running = true;
-      await (worker as denoHTTPWorker).warmRequest();
+      try {
+        await (worker as denoHTTPWorker).warmRequest();
+      } catch (err) {
+        // Clean up the worker (destroying its http.Agent) if the warm
+        // request fails, e.g. because the process died right after the
+        // socket came up.
+        (worker as denoHTTPWorker)._terminate();
+        throw err;
+      }
 
       return worker;
     })()
@@ -327,7 +448,13 @@ class denoHTTPWorker {
       forceKill(this.#process.pid!);
     }
     this.#agent.destroy();
-    fs.rm(this.#socketFile).catch(() => {});
+    // The socket file lives in a private directory created by
+    // newDenoHTTPWorker (for the fs.watch readiness detection); remove the
+    // whole directory, not just the socket file.
+    fs.rm(path.dirname(this.#socketFile), {
+      recursive: true,
+      force: true,
+    }).catch(() => {});
     for (const onexit of this.#onexitListeners) {
       onexit(code ?? 1, signal ?? "");
     }


### PR DESCRIPTION
**This is an experimental alternative to #120, not a competing proposal.** Tom asked how complex the fs.watch route to readiness detection turns out in practice, as a comparison point for #120's 1ms connect-retry loop. This PR is that data point. Same goal (stop wasting up to 20ms in the old `fs.stat` poll), different mechanism. It also includes #120's early-exit leak fixes (675f159) so the two branches differ only in the readiness mechanism.

## The fs.watch approach

Instead of polling for the socket file (main) or retry-connecting to it (#120), watch the directory that will contain it and resolve readiness when the file appears. Sounds simpler; the edge cases say otherwise:

1. **You can't watch the shared tmpdir.** The socket used to live directly in `os.tmpdir()`; a watcher there wakes for every temp file created by anything on the machine, for every pending worker. So each worker now gets a private `mkdtemp` directory — which means directory (not just socket-file) cleanup on every exit path: early process exit, `_terminate()`, and watcher failure.
2. **The private directory overflowed `SUN_LEN`.** Unix socket paths max out around 104 bytes on macOS; the extra directory component plus the old UUID filename made Deno's `listen()` throw `path must be shorter than SUN_LEN`. The socket filename had to shrink (the directory is the unique part now).
3. **Event args are not portable.** Creation arrives as `"rename"` on inotify, varies on FSEvents/kqueue, and the `filename` argument isn't guaranteed. So every event just triggers an existence check — the watch event is a wake-up, not a signal.
4. **File-created-before-watcher race.** One existence check after the watcher is established, or the file slips through unobserved.
5. **fs.watch is documented as lossy.** On macOS the FSEvents stream starts asynchronously, so events right after `watch()` returns can be missed. A coarse 250ms fallback poll bounds a missed event instead of hanging forever — i.e. the robust version of fs.watch still contains the poll it was meant to replace.
6. **File existence ≠ accepting connections.** The file can exist before `listen()` completes, so after the watch event we still confirm with a connect, retrying at 1ms — partially reintroducing #120's entire mechanism as a post-step.
7. **No event for "process died".** The connect-retry loop notices `exited` on its next iteration for free; the watch promise must have process exit explicitly wired in (plus an `exited` re-check for an exit that lands before the listener is registered) to preserve `EarlyExitDenoHTTPWorkerError`.
8. **Watcher lifecycle.** An open `FSWatcher` (or the fallback interval) keeps the Node event loop alive, so every settle path — success, watcher error, process exit — must close both. And a watcher error (e.g. inotify watch limit) is a failure mode the poll/connect designs don't have at all: it leaves a live Deno process that nothing else reaps, so that path must kill the process too.

## Benchmarks

Same methodology as #120: spawn a worker with a one-line guest 15 times (after one warmup), measuring spawn → first successful request, medians reported. Linux numbers are node:22-slim + Deno 2.8.2 in Docker on the same M2 Mac.

| | macOS (M2) | Linux (Docker) |
|---|---|---|
| main (20ms stat poll) | 44.7ms | 27.2ms |
| #120 (1ms connect-retry) | 26.0ms | 22.5ms |
| **this PR (fs.watch)** | **64.4ms** | **22.1ms** |

**macOS is a regression past even the stat poll.** Node's fs.watch uses FSEvents there, and a *freshly created* watcher takes ~36ms to deliver its first event (stream startup; ~13ms once warm — measured with a standalone script). Since every spawn creates a fresh watcher, that startup cost lands on every spawn: 24ms (socket ready) + ~36ms (event delivery) + ~2ms (confirm + warm) ≈ 64ms.

**Linux is good.** inotify delivers in ~0.3ms even from a fresh watcher, so fs.watch edges out the connect-retry's ~0.5ms average detection lag — by a margin (~0.4ms) within run-to-run noise. Prod runs Linux, so the latency story there is "tied with #120".

## Complexity verdict

| | #120 connect-retry | this PR fs.watch |
|---|---|---|
| diff in `DenoHTTPWorker.ts` | +34 / −8 | +156 / −29 |
| readiness moving parts | 1 loop | watcher + fallback interval + initial check + exit wiring + confirm-connect loop |
| edge cases handled | 2 (early exit, warm-request failure) | those 2 + the 8 above |
| new failure modes introduced | none | watcher error (must reap live process), missed watch event (needs fallback poll), socket path length |
| platform-dependent behavior | none | FSEvents startup latency makes macOS 2.4x slower; event semantics differ per platform |

The fs.watch version is roughly 4x the code, needs a confirming connect *and* a fallback poll (both mechanisms it was meant to replace, kept as subordinate parts), and is significantly slower on macOS for a reason that can't be tuned from Node's API. On Linux it's at parity with #120, not ahead of it. Unless sub-millisecond Linux detection ever matters, the connect-retry in #120 wins on simplicity, portability, and worst-case behavior.

Tests (20) and lint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/val-town/deno-http-worker/pull/121" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->