### PR TITLE
Add bench and optimizations

### DIFF
--- a/.changeset/silent-waves-throw.md
+++ b/.changeset/silent-waves-throw.md
@@ -1,0 +1,5 @@
+---
+"@valtown/deno-http-worker": patch
+---
+
+Add flags for optimizations: faster socket check, skipping warm request, and caching bootstrap file

--- a/src/DenoHTTPWorker.bench.ts
+++ b/src/DenoHTTPWorker.bench.ts
@@ -1,0 +1,54 @@
+import { describe, bench } from "vitest";
+import { newDenoHTTPWorker } from "./index.js";
+
+const DEFAULT_HTTP_VAL = `export default { async fetch (req: Request): Promise<Response> {
+  let headers = {};
+  for (let [key, value] of req.headers.entries()) {
+    headers[key] = value;
+  }
+  return Response.json({ ok: req.url, headers: headers })
+} }`;
+
+const opts = { iterations: 20 };
+
+describe("spawn", () => {
+  bench(
+    "main",
+    async () => {
+      const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL);
+      worker.terminate();
+    },
+    opts
+  );
+  bench(
+    "fast ready",
+    async () => {
+      const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL, {
+        next: { fastReady: true },
+      });
+      worker.terminate();
+    },
+    opts
+  );
+  bench(
+    "cache bootstrap",
+    async () => {
+      const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL, {
+        next: { cacheBootstrap: true },
+      });
+      worker.terminate();
+    },
+    opts
+  );
+
+  bench(
+    "both",
+    async () => {
+      const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL, {
+        next: { cacheBootstrap: true, fastReady: true },
+      });
+      worker.terminate();
+    },
+    opts
+  );
+});

--- a/src/DenoHTTPWorker.bench.ts
+++ b/src/DenoHTTPWorker.bench.ts
@@ -9,7 +9,7 @@ const DEFAULT_HTTP_VAL = `export default { async fetch (req: Request): Promise<R
   return Response.json({ ok: req.url, headers: headers })
 } }`;
 
-const opts = { iterations: 20 };
+const opts = { iterations: 200 };
 
 describe("spawn", () => {
   bench(
@@ -40,12 +40,22 @@ describe("spawn", () => {
     },
     opts
   );
-
   bench(
-    "both",
+    "skip warm",
     async () => {
       const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL, {
-        next: { cacheBootstrap: true, fastReady: true },
+        next: { skipWarm: true },
+      });
+      worker.terminate();
+    },
+    opts
+  );
+
+  bench(
+    "all",
+    async () => {
+      const worker = await newDenoHTTPWorker(DEFAULT_HTTP_VAL, {
+        next: { cacheBootstrap: true, fastReady: true, skipWarm: true },
       });
       worker.terminate();
     },

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -5,6 +5,7 @@ import readline from "node:readline";
 import http from "node:http";
 import fs from "node:fs/promises";
 import os from "node:os";
+import net from "node:net";
 
 import { fileURLToPath } from "node:url";
 
@@ -106,7 +107,14 @@ export interface DenoWorkerOptions {
     args: string[],
     options: SpawnOptions
   ) => MinimalChildProcess;
+
+  next?: {
+    cacheBootstrap?: boolean;
+    fastReady?: boolean;
+  };
 }
+
+let bootstrapCache = new Map<string, string>();
 
 /**
  * Create a new DenoHTTPWorker. This function will start a worker and being
@@ -115,6 +123,7 @@ export const newDenoHTTPWorker = async (
   script: string | URL,
   options: Partial<DenoWorkerOptions> = {}
 ): Promise<DenoHTTPWorker> => {
+  // Synchronous work
   const _options: DenoWorkerOptions = {
     denoExecutable: "deno",
     denoBootstrapScriptPath: DEFAULT_DENO_BOOTSTRAP_SCRIPT_PATH,
@@ -182,10 +191,21 @@ export const newDenoHTTPWorker = async (
       ? _options.denoExecutable
       : (_options.denoExecutable[0] as string);
 
-  const bootstrap = await fs.readFile(
-    _options.denoBootstrapScriptPath,
-    "utf-8"
-  );
+  let bootstrap: string | undefined;
+  if (_options.next?.cacheBootstrap) {
+    bootstrap = bootstrapCache.get(_options.denoBootstrapScriptPath);
+
+    if (!bootstrap) {
+      bootstrap = encodeURIComponent(
+        await fs.readFile(_options.denoBootstrapScriptPath, "utf-8")
+      );
+      bootstrapCache.set(_options.denoBootstrapScriptPath, bootstrap);
+    }
+  } else {
+    bootstrap = encodeURIComponent(
+      await fs.readFile(_options.denoBootstrapScriptPath, "utf-8")
+    );
+  }
 
   return new Promise((resolve, reject) => {
     (async (): Promise<DenoHTTPWorker> => {
@@ -195,7 +215,7 @@ export const newDenoHTTPWorker = async (
           : _options.denoExecutable.slice(1)),
         "run",
         ..._options.runFlags,
-        `data:text/typescript,${encodeURIComponent(bootstrap)}`,
+        `data:text/typescript,${bootstrap}`,
         ...scriptArgs,
       ];
       if (_options.printCommandAndArguments) {
@@ -237,20 +257,48 @@ export const newDenoHTTPWorker = async (
           console.error("[deno]", line);
         });
       }
-
-      // Wait for the socket file to be created by the Deno process.
-      for (;;) {
-        if (exited) {
-          break;
+      if (_options.next?.fastReady) {
+        // Try connecting to the Deno process every 1ms
+        for (;;) {
+          if (exited) {
+            // The "exit" handler above has already rejected this promise with
+            // EarlyExitDenoHTTPWorkerError. Throw (harmlessly swallowed by the
+            // settled promise) instead of falling through and constructing a
+            // worker whose http.Agent would never be destroyed.
+            throw new Error("Deno exited before being ready");
+          }
+          const connected = await new Promise<boolean>((resolve) => {
+            const socket = net.connect({ path: socketFile });
+            socket.once("connect", () => {
+              socket.destroy();
+              resolve(true);
+            });
+            socket.once("error", () => {
+              socket.destroy();
+              resolve(false);
+            });
+          });
+          if (connected) {
+            break;
+          }
+          await new Promise((resolve) => setTimeout(resolve, 1));
         }
-        try {
-          await fs.stat(socketFile);
-          // File exists
-          break;
-        } catch (_err) {
-          await new Promise((resolve) => setTimeout(resolve, 20));
+      } else {
+        // Wait for the socket file to be created by the Deno process.
+        for (;;) {
+          if (exited) {
+            break;
+          }
+          try {
+            await fs.stat(socketFile);
+            // File exists
+            break;
+          } catch (_err) {
+            await new Promise((resolve) => setTimeout(resolve, 20));
+          }
         }
       }
+
       worker = new denoHTTPWorker(socketFile, process, stdout, stderr);
       running = true;
       await (worker as denoHTTPWorker).warmRequest();

--- a/src/DenoHTTPWorker.ts
+++ b/src/DenoHTTPWorker.ts
@@ -111,6 +111,7 @@ export interface DenoWorkerOptions {
   next?: {
     cacheBootstrap?: boolean;
     fastReady?: boolean;
+    skipWarm?: boolean;
   };
 }
 
@@ -301,7 +302,17 @@ export const newDenoHTTPWorker = async (
 
       worker = new denoHTTPWorker(socketFile, process, stdout, stderr);
       running = true;
-      await (worker as denoHTTPWorker).warmRequest();
+      if (!_options.next?.skipWarm) {
+        try {
+          await (worker as denoHTTPWorker).warmRequest();
+        } catch (err) {
+          // Clean up the worker (destroying its http.Agent) if the warmAdd a comment on  line R272Add diff commentMarkdown input:  edit mode selected.WritePreviewAdd a suggestionHeadingBoldItalicQuoteCodeLinkUnordered listNumbered listTask listMentionReferenceMore Formatting tools items 0Saved repliesAdd FilesPaste, drop, or click to add filesCancelCommentStart a review
+          // request fails, e.g. because the process died right after the
+          // socket came up.
+          (worker as denoHTTPWorker)._terminate();
+          throw err;
+        }
+      }
 
       return worker;
     })()


### PR DESCRIPTION
This adds the proposed big optimization (faster, more frequent socket checking) as a flag so that we can have benchmarks for the two options. Bench results:

```
 ✓ src/DenoHTTPWorker.bench.ts > spawn 34393ms
     name                  hz      min      max     mean      p75      p99     p995     p999     rme  samples
   · main             24.9062  22.2201  44.9020  40.1506  44.1028  44.6241  44.8004  44.9020  ±2.80%      200
   · fast ready       42.1691  22.1397  41.9539  23.7140  24.2270  26.5454  26.6627  41.9539  ±0.88%      200
   · cache bootstrap  24.8246  22.1124  45.4482  40.2826  43.9719  45.1982  45.3230  45.4482  ±2.69%      200
   · skip warm        24.6163  21.7591  44.0015  40.6235  43.5051  43.9080  43.9617  44.0015  ±2.42%      200
   · all              43.5508  21.5368  31.4185  22.9617  22.8635  25.3224  26.4769  31.4185  ±0.53%      200

 BENCH  Summary

  all - src/DenoHTTPWorker.bench.ts > spawn
    1.03x faster than fast ready
    1.75x faster than main
    1.75x faster than cache bootstrap
    1.77x faster than skip warm
```