### PR TITLE
Add renovate schedule and minimum release age

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"]
+  "extends": ["config:recommended"],
+  "minimumReleaseAge": "14 days",
+  "timezone": "America/New_York",
+  "schedule": ["at 1:00 pm on the first day of the month"]
 }


### PR DESCRIPTION
Adding some basic configuration to renovate to this repo - mostly the important part is the minimum release age, which prevents us from adopting packages right after they're published when they're most likely to have undetected exploits.